### PR TITLE
systemd-boot snapshot kernel restore

### DIFF
--- a/include/libze/libze_plugin_manager.h
+++ b/include/libze/libze_plugin_manager.h
@@ -20,6 +20,7 @@ typedef struct libze_activate_data {
 typedef struct libze_create_data {
     char const *const be_mountpoint;
     char const *const be_name;
+    boolean_t from_snapshot;
 } libze_create_data;
 
 typedef libze_error (*plugin_fn_init)(libze_handle *lzeh);

--- a/include/libze/libze_plugin_manager.h
+++ b/include/libze/libze_plugin_manager.h
@@ -23,6 +23,11 @@ typedef struct libze_create_data {
     boolean_t from_snapshot;
 } libze_create_data;
 
+typedef struct libze_snap_data {
+    char const *const be_name;
+    boolean_t is_root;
+} libze_snap_data;
+
 typedef libze_error (*plugin_fn_init)(libze_handle *lzeh);
 
 typedef libze_error (*plugin_fn_pre_activate)(libze_handle *lzeh);
@@ -42,6 +47,8 @@ typedef libze_error (*plugin_fn_post_rename)(libze_handle *lzeh,
                                              char const be_name_old[LIBZE_MAX_PATH_LEN],
                                              char const be_name_new[LIBZE_MAX_PATH_LEN]);
 
+typedef libze_error (*plugin_fn_pre_snapshot)(libze_handle *lzeh, libze_snap_data *snap_data);
+
 typedef struct libze_plugin_fn_export {
     plugin_fn_init plugin_init;
     plugin_fn_pre_activate plugin_pre_activate;
@@ -50,6 +57,7 @@ typedef struct libze_plugin_fn_export {
     plugin_fn_post_destroy plugin_post_destroy;
     plugin_fn_post_create plugin_post_create;
     plugin_fn_post_rename plugin_post_rename;
+    plugin_fn_pre_snapshot plugin_pre_snapshot;
 } libze_plugin_fn_export;
 
 libze_plugin_manager_error

--- a/include/libze/libze_util.h
+++ b/include/libze/libze_util.h
@@ -65,6 +65,9 @@ libze_util_copydir(char const directory_path[LIBZE_MAX_PATH_LEN],
 int
 libze_util_rmdir(char const directory_path[LIBZE_MAX_PATH_LEN]);
 
+int
+libze_util_mkdir(char const directory_path[LIBZE_MAX_PATH_LEN], mode_t mode);
+
 libze_error
 libze_util_replace_string(char const *to_replace, char const *replacement, size_t line_length,
                           char const line[line_length], size_t line_replaced_length,

--- a/include/libze_plugin/libze_plugin_systemdboot.h
+++ b/include/libze_plugin/libze_plugin_systemdboot.h
@@ -27,6 +27,9 @@ libze_error
 libze_plugin_systemdboot_post_rename(libze_handle *lzeh, char const be_name_old[LIBZE_MAX_PATH_LEN],
                                      char const be_name_new[LIBZE_MAX_PATH_LEN]);
 
+libze_error
+libze_plugin_systemdboot_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_data);
+
 libze_plugin_fn_export const exported_plugin = {
     .plugin_init = libze_plugin_systemdboot_init,
     .plugin_pre_activate = libze_plugin_systemdboot_pre_activate,
@@ -34,6 +37,8 @@ libze_plugin_fn_export const exported_plugin = {
     .plugin_post_activate = libze_plugin_systemdboot_post_activate,
     .plugin_post_destroy = libze_plugin_systemdboot_post_destroy,
     .plugin_post_create = libze_plugin_systemdboot_post_create,
-    .plugin_post_rename = libze_plugin_systemdboot_post_rename};
+    .plugin_post_rename = libze_plugin_systemdboot_post_rename,
+    .plugin_pre_snapshot = libze_plugin_systemdboot_pre_snapshot
+};
 
 #endif // ZECTL_LIBZE_PLUGIN_SYSTEMDBOOT_H

--- a/lib/libze/libze.c
+++ b/lib/libze/libze.c
@@ -2708,6 +2708,21 @@ libze_snapshot(libze_handle *lzeh, char const boot_environment[static 1]) {
         }
     }
 
+    libze_snap_data sd = {
+        .be_name = boot_environment_buf,
+        .is_root = B_FALSE
+    };
+
+    /* Plugin - Pre snapshot */
+    if (lzeh->lz_funcs != NULL) {
+        if (libze_is_root_be(lzeh, be_ds)) {
+            sd.is_root = B_TRUE;
+        }
+        if ((ret = lzeh->lz_funcs->plugin_pre_snapshot(lzeh, &sd)) != LIBZE_ERROR_SUCCESS) {
+            return ret;
+        }
+    }
+
     if (zfs_snapshot(lzeh->lzh, snap_buf, B_TRUE, NULL) != 0) {
         return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to take snapshot (%s).\n",
                                snap_buf);

--- a/lib/libze/libze.c
+++ b/lib/libze/libze.c
@@ -1777,7 +1777,7 @@ prepare_create_from_existing(libze_handle *lzeh, char const be_source[ZFS_MAX_DA
  * @post if be_zh != root dataset, be_zh unmounted on exit
  */
 static libze_error
-post_create(libze_handle *lzeh, libze_create_options *options) {
+post_create(libze_handle *lzeh, libze_create_options *options, boolean_t is_snap) {
     libze_error ret = LIBZE_ERROR_SUCCESS;
 
     if (lzeh->lz_funcs == NULL) {
@@ -1806,7 +1806,11 @@ post_create(libze_handle *lzeh, libze_create_options *options) {
         }
     }
 
-    libze_create_data create_data = {.be_name = options->be_name, .be_mountpoint = tmp_dirname};
+    libze_create_data create_data = {
+            .be_name = options->be_name,
+            .be_mountpoint = tmp_dirname,
+            .from_snapshot = is_snap
+    };
 
     if (lzeh->lz_funcs->plugin_post_create(lzeh, &create_data) != 0) {
         ret = libze_error_set(lzeh, LIBZE_ERROR_PLUGIN, "Failed to run post-create hook\n");
@@ -1921,7 +1925,7 @@ libze_create(libze_handle *lzeh, libze_create_options *options) {
         }
     }
 
-    ret = post_create(lzeh, options);
+    ret = post_create(lzeh, options, cdata.is_snap);
 
     return ret;
 }

--- a/lib/libze/libze_util.c
+++ b/lib/libze/libze_util.c
@@ -610,6 +610,56 @@ libze_util_rmdir(char const directory_path[LIBZE_MAX_PATH_LEN]) {
 }
 
 /**
+ * @brief Create a directory recursively
+ *
+ * @param directory_path Directory to remove
+ * @return 0 on success else appropriate error as returned by errno
+ */
+int
+libze_util_mkdir(char const directory_path[LIBZE_MAX_PATH_LEN], mode_t mode) {
+    char path_buf[LIBZE_MAX_PATH_LEN];
+    (void) strlcpy(path_buf, directory_path, LIBZE_MAX_PATH_LEN);
+
+    struct stat newdir_st;
+
+    for (char * p = strchr(path_buf + 1, '/'); p; p = strchr(p + 1, '/')) {
+        /* Split at slash */
+        *p = '\0';
+
+        /* Create destination directory. */
+        int err = mkdir(path_buf, mode);
+        if (err != 0) {
+            errno = 0;
+            if (stat(path_buf, &newdir_st) != 0) {
+                return errno;
+            }
+
+            if (!S_ISDIR(newdir_st.st_mode)) {
+                return ENOTDIR;
+            }
+        }
+
+        /* Restore slash */
+        *p = '/';
+    }
+
+    /* Create destination directory. */
+    int err = mkdir(path_buf, mode);
+    if (err != 0) {
+        errno = 0;
+        if (stat(path_buf, &newdir_st) != 0) {
+            return errno;
+        }
+
+        if (!S_ISDIR(newdir_st.st_mode)) {
+            return ENOTDIR;
+        }
+    }
+
+    return 0;
+}
+
+/**
  * @brief Copy a directory recursively
  *
  * @param directory_path Directory to copy

--- a/lib/libze_plugin/libze_plugin_systemdboot.c
+++ b/lib/libze_plugin/libze_plugin_systemdboot.c
@@ -714,8 +714,8 @@ get_loader_line_from_regex(libze_handle *lzeh, void *data, char const line[LIBZE
 
     char replace_two[LIBZE_MAX_PATH_LEN] = "";
 
-    int rlen = snprintf(replace_two, LIBZE_MAX_PATH_LEN, "\\1%s-%s.conf\n", SYSTEMDBOOT_ENTRY_PREFIX,
-                        rmd->be_name);
+    int rlen = snprintf(replace_two, LIBZE_MAX_PATH_LEN, "\\1%s-%s.conf\n",
+                        SYSTEMDBOOT_ENTRY_PREFIX, rmd->be_name);
     if (rlen >= LIBZE_MAX_PATH_LEN) {
         ret = libze_error_set(lzeh, ret, "Exceeded max path length for regex buffer.\n");
         goto done;
@@ -1156,7 +1156,7 @@ libze_plugin_systemdboot_post_create(libze_handle *lzeh, libze_create_data *crea
     ret = libze_be_prop_get(lzeh, kernel_snap_dir, "kernelsnapshotdirectory", namespace_buf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN,
-                "Couldn't access systemdboot:kernelsnapshotdirectory property.\n");
+                               "Couldn't access systemdboot:kernelsnapshotdirectory property.\n");
     }
 
     ret = form_loader_entry_config(efi_mountpoint, create_data->be_name, new_loader_buf);
@@ -1169,52 +1169,59 @@ libze_plugin_systemdboot_post_create(libze_handle *lzeh, libze_create_data *crea
         char fstab_buf[LIBZE_MAX_PATH_LEN];
         char fstab_dest_buf[LIBZE_MAX_PATH_LEN];
         /* Source directory */
-        if (libze_util_concat(create_data->be_mountpoint, "", kernel_snap_dir, LIBZE_MAX_PATH_LEN, kernel_mounted_snap_dir) != 0) {
+        if (libze_util_concat(create_data->be_mountpoint, "", kernel_snap_dir, LIBZE_MAX_PATH_LEN,
+                              kernel_mounted_snap_dir) != 0) {
             return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                    "Mounted BE kernelsnapshotdirectory exceeds max path length.\n");
+                                   "Mounted BE kernelsnapshotdirectory exceeds max path length.\n");
         }
 
         /* Source loader path */
-        iret = libze_util_concat(kernel_mounted_snap_dir, "/loader/entries/", "org.zectl-%ZECTLBE%.conf", LIBZE_MAX_PATH_LEN, loader_buf);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "/loader/entries/",
+                                 "org.zectl-%ZECTLBE%.conf", LIBZE_MAX_PATH_LEN, loader_buf);
         if (iret != 0) {
             return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                    "BE kernelsnapshotdirectory subdirectory path to "
-                    "org.zectl-%ZECTLBE%.conf exceeds max path length.\n");
+                                   "BE kernelsnapshotdirectory subdirectory path to "
+                                   "org.zectl-%ZECTLBE%.conf exceeds max path length.\n");
         }
 
         /* Replace in loader.conf */
         (void) strlcpy(loader_replace, "%ZECTLBE%", LIBZE_MAX_PATH_LEN);
 
         /* Kernel directory source */
-        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/env/boot", LIBZE_MAX_PATH_LEN, kernel_source_dir);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/env/boot", LIBZE_MAX_PATH_LEN,
+                                 kernel_source_dir);
         if (iret != 0) {
             return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                    "Mounted BE kernelsnapshotdirectory subdirectory path "
-                           "to kernels exceeds max path length.\n");
+                                   "Mounted BE kernelsnapshotdirectory subdirectory path "
+                                   "to kernels exceeds max path length.\n");
         }
         /* fstab source */
-        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/etc/fstab", LIBZE_MAX_PATH_LEN, fstab_buf);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/etc/fstab", LIBZE_MAX_PATH_LEN,
+                                 fstab_buf);
         if (iret != 0) {
             return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                    "Mounted BE kernelsnapshotdirectory subdirectory path "
-                           "to fstab exceeds max path length.\n");
+                                   "Mounted BE kernelsnapshotdirectory subdirectory path "
+                                   "to fstab exceeds max path length.\n");
         }
         /* fstab dest */
-        iret = libze_util_concat(create_data->be_mountpoint, "", "/etc/fstab", LIBZE_MAX_PATH_LEN, fstab_dest_buf);
+        iret = libze_util_concat(create_data->be_mountpoint, "", "/etc/fstab", LIBZE_MAX_PATH_LEN,
+                                 fstab_dest_buf);
         if (iret != 0) {
             return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                    "Path to fstab exceeds max path length.\n");
+                                   "Path to fstab exceeds max path length.\n");
         }
         iret = libze_util_copy_file(fstab_buf, fstab_dest_buf);
         if (iret != 0) {
-            return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to copy %s to %s.\n", fstab_buf,
-                    fstab_dest_buf);
+            return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to copy %s to %s.\n",
+                                   fstab_buf, fstab_dest_buf);
         }
 
     } else {
         /* Get Active BE to replace in loader.conf */
-        if (libze_boot_env_name(lzeh->env_activated_path, ZFS_MAX_DATASET_NAME_LEN, loader_replace) != 0) {
-            return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN, "Bootfs exceeds max path length.\n");
+        if (libze_boot_env_name(lzeh->env_activated_path, ZFS_MAX_DATASET_NAME_LEN,
+                                loader_replace) != 0) {
+            return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
+                                   "Bootfs exceeds max path length.\n");
         }
 
         /* loader path */
@@ -1225,7 +1232,7 @@ libze_plugin_systemdboot_post_create(libze_handle *lzeh, libze_create_data *crea
         }
         if (ret != LIBZE_ERROR_SUCCESS) {
             return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                    "BE loader path exceeds max path length.\n");
+                                   "BE loader path exceeds max path length.\n");
         }
     }
 
@@ -1238,13 +1245,13 @@ libze_plugin_systemdboot_post_create(libze_handle *lzeh, libze_create_data *crea
     ret = form_loader_entry_path(efi_mountpoint, "env", create_data->be_name, new_loader_buf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-        "BE loader path exceeds max path length.\n");
+                               "BE loader path exceeds max path length.\n");
     }
 
     iret = libze_util_copydir(kernel_source_dir, new_loader_buf);
     if (iret != 0) {
-        return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to copy %s to %s.\n", kernel_source_dir,
-                               new_loader_buf);
+        return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to copy %s to %s.\n",
+                               kernel_source_dir, new_loader_buf);
     }
 
     if (create_data->from_snapshot) {
@@ -1426,8 +1433,8 @@ libze_plugin_systemdboot_post_rename(libze_handle *lzeh, char const be_name_old[
  *        Mounts the dataset being snapshotted (if it is not the currently mounted dataset).
  *        Copies the following for that environment to $kernelsnapshotdirectory.
  *           $esp/env/org.zectl-$be -> $kernelsnapshotdirectory/env/boot
- *           $esp/loader/entries/org.zectl-$be.conf -> $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf
- *        Unmounts the dataset
+ *           $esp/loader/entries/org.zectl-$be.conf ->
+ * $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf Unmounts the dataset
  *
  * @param[in,out] lzeh   libze handle
  * @param[in] snap_data  Snapshot related data
@@ -1457,23 +1464,23 @@ libze_plugin_systemdboot_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_
     if (libze_plugin_form_namespace(PLUGIN_SYSTEMDBOOT, namespace_buf) !=
         LIBZE_PLUGIN_MANAGER_ERROR_SUCCESS) {
         return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Exceeded max property name length.\n");
+                               "Exceeded max property name length.\n");
     }
 
     ret = libze_be_prop_get(lzeh, efi_mountpoint, "efi", namespace_buf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN,
-                "Couldn't access systemdboot:efi property.\n");
+                               "Couldn't access systemdboot:efi property.\n");
     }
     ret = libze_be_prop_get(lzeh, boot_mountpoint, "boot", namespace_buf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN,
-                "Couldn't access systemdboot:boot property.\n");
+                               "Couldn't access systemdboot:boot property.\n");
     }
     ret = libze_be_prop_get(lzeh, kernel_snap_dir, "kernelsnapshotdirectory", namespace_buf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         return libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN,
-                "Couldn't access systemdboot:kernelsnapshotdirectory property.\n");
+                               "Couldn't access systemdboot:kernelsnapshotdirectory property.\n");
     }
 
     if (snap_data->is_root) {
@@ -1486,97 +1493,110 @@ libze_plugin_systemdboot_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_
         }
     }
 
-    if (libze_util_concat(mountpoint_buf, "", kernel_snap_dir, LIBZE_MAX_PATH_LEN, kernel_mounted_snap_dir) != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Mounted BE kernelsnapshotdirectory subdirectory path exceeds max path length.\n");
+    if (libze_util_concat(mountpoint_buf, "", kernel_snap_dir, LIBZE_MAX_PATH_LEN,
+                          kernel_mounted_snap_dir) != 0) {
+        ret = libze_error_set(
+            lzeh, LIBZE_ERROR_MAXPATHLEN,
+            "Mounted BE kernelsnapshotdirectory subdirectory path exceeds max path length.\n");
         goto err;
     }
 
     ret = form_loader_entry_path(efi_mountpoint, "env", snap_data->be_name, kernel_dir_buf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "BE kernel directory path exceeds max path length.\n");
+                              "BE kernel directory path exceeds max path length.\n");
         goto err;
     }
     ret = form_loader_entry_config(efi_mountpoint, snap_data->be_name, kernel_loader_conf);
     if (ret != LIBZE_ERROR_SUCCESS) {
         ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "BE config file path exceeds max path length.\n");
+                              "BE config file path exceeds max path length.\n");
         goto err;
     }
 
     /* create fstab path */
     if (libze_util_concat(mountpoint_buf, "", "/etc/fstab", LIBZE_MAX_PATH_LEN, fstab_buf) != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Mounted BE kernelsnapshotdirectory subdirectory path exceeds max path length.\n");
+        ret = libze_error_set(
+            lzeh, LIBZE_ERROR_MAXPATHLEN,
+            "Mounted BE kernelsnapshotdirectory subdirectory path exceeds max path length.\n");
         goto err;
     }
 
     /* Create destination directories. */
 
-    int iret = libze_util_concat(kernel_mounted_snap_dir, "", "/env/boot", LIBZE_MAX_PATH_LEN, kernel_boot_dir);
+    int iret = libze_util_concat(kernel_mounted_snap_dir, "", "/env/boot", LIBZE_MAX_PATH_LEN,
+                                 kernel_boot_dir);
     if (iret == 0) {
-        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/loader/entries", LIBZE_MAX_PATH_LEN, kernel_loader_dir);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/loader/entries", LIBZE_MAX_PATH_LEN,
+                                 kernel_loader_dir);
     }
     if (iret == 0) {
-        iret = libze_util_concat(kernel_mounted_snap_dir, "/loader/entries/", "org.zectl-%ZECTLBE%.conf", LIBZE_MAX_PATH_LEN, kernel_loader_conf_dest);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "/loader/entries/",
+                                 "org.zectl-%ZECTLBE%.conf", LIBZE_MAX_PATH_LEN,
+                                 kernel_loader_conf_dest);
     }
     if (iret == 0) {
-        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/etc/", LIBZE_MAX_PATH_LEN, etc_buf_dir);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "", "/etc/", LIBZE_MAX_PATH_LEN,
+                                 etc_buf_dir);
     }
     if (iret == 0) {
-        iret = libze_util_concat(kernel_mounted_snap_dir, "/etc/", "fstab", LIBZE_MAX_PATH_LEN, fstab_buf_dest);
+        iret = libze_util_concat(kernel_mounted_snap_dir, "/etc/", "fstab", LIBZE_MAX_PATH_LEN,
+                                 fstab_buf_dest);
     }
     if (iret != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "BE kernelsnapshotdirectory subdirectory path exceeds max path length.\n");
+        ret = libze_error_set(
+            lzeh, LIBZE_ERROR_MAXPATHLEN,
+            "BE kernelsnapshotdirectory subdirectory path exceeds max path length.\n");
         goto err;
     }
 
     iret = libze_util_mkdir(kernel_boot_dir, 0700);
     if (iret != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Failed to create directory (%s).\n", kernel_boot_dir);
+        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN, "Failed to create directory (%s).\n",
+                              kernel_boot_dir);
         goto err;
     }
     iret = libze_util_mkdir(kernel_loader_dir, 0700);
     if (iret != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Failed to create directory (%s).\n", kernel_loader_dir);
+        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN, "Failed to create directory (%s).\n",
+                              kernel_loader_dir);
         goto err;
     }
     iret = libze_util_mkdir(etc_buf_dir, 0700);
     if (iret != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Failed to create directory (%s).\n", etc_buf_dir);
+        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN, "Failed to create directory (%s).\n",
+                              etc_buf_dir);
         goto err;
     }
 
     /* Copy the following for that environment to $kernelsnapshotdirectory.
      *  $esp/env/org.zectl-$be -> $kernelsnapshotdirectory/env/boot
-     *  $esp/loader/entries/org.zectl-$be.conf -> $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf
+     *  $esp/loader/entries/org.zectl-$be.conf ->
+     * $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf
      */
 
     if (libze_util_copydir(kernel_dir_buf, kernel_boot_dir) != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Failed to copy directory (%s -> %s).\n", kernel_loader_conf, kernel_loader_conf_dest);
+        ret =
+            libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN, "Failed to copy directory (%s -> %s).\n",
+                            kernel_loader_conf, kernel_loader_conf_dest);
         goto err;
     }
 
     /* Replace BE with %ZECTLBE% */
-    ret = replace_be_name(lzeh, "%ZECTLBE%", snap_data->be_name, kernel_loader_conf, kernel_loader_conf_dest);
+    ret = replace_be_name(lzeh, "%ZECTLBE%", snap_data->be_name, kernel_loader_conf,
+                          kernel_loader_conf_dest);
     if (ret != LIBZE_ERROR_SUCCESS) {
         goto err;
     }
     struct replace_fstab_data data = {.active_be = snap_data->be_name,
-            .be_name = "%ZECTLBE%",
-            .boot_mountpoint = boot_mountpoint,
-            .efi_mountpoint = efi_mountpoint};
+                                      .be_name = "%ZECTLBE%",
+                                      .boot_mountpoint = boot_mountpoint,
+                                      .efi_mountpoint = efi_mountpoint};
 
     ret = replace_matched(lzeh, fstab_buf, fstab_buf_dest, get_fstab_line_from_regex, &data);
     if (ret != LIBZE_ERROR_SUCCESS) {
-        ret =
-                libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to replace lines in %s.\n", fstab_buf_dest);
+        ret = libze_error_set(lzeh, LIBZE_ERROR_UNKNOWN, "Failed to replace lines in %s.\n",
+                              fstab_buf_dest);
         goto err;
     }
 

--- a/lib/libze_plugin/libze_plugin_systemdboot.c
+++ b/lib/libze_plugin/libze_plugin_systemdboot.c
@@ -1130,7 +1130,7 @@ libze_plugin_systemdboot_post_create(libze_handle *lzeh, libze_create_data *crea
     if (libze_boot_env_name(lzeh->env_activated_path, ZFS_MAX_DATASET_NAME_LEN, active_be) != 0) {
         return libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN, "Bootfs exceeds max path length.\n");
     }
-
+    
     char boot_mountpoint[ZFS_MAXPROPLEN];
     char efi_mountpoint[ZFS_MAXPROPLEN];
 
@@ -1461,11 +1461,6 @@ libze_plugin_systemdboot_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_
      *  $esp/loader/entries/org.zectl-$be.conf -> $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf
      */
 
-    if (libze_util_copy_file(kernel_loader_conf, kernel_loader_conf_dest) != 0) {
-        ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
-                "Failed to copy file (%s -> %s).\n", kernel_loader_conf, kernel_loader_conf_dest);
-        goto err;
-    }
     if (libze_util_copydir(kernel_dir_buf, kernel_boot_dir) != 0) {
         ret = libze_error_set(lzeh, LIBZE_ERROR_MAXPATHLEN,
                 "Failed to copy directory (%s -> %s).\n", kernel_loader_conf, kernel_loader_conf_dest);

--- a/lib/libze_plugin/libze_plugin_systemdboot.c
+++ b/lib/libze_plugin/libze_plugin_systemdboot.c
@@ -1352,3 +1352,34 @@ libze_plugin_systemdboot_post_rename(libze_handle *lzeh, char const be_name_old[
 
     return ret;
 }
+
+libze_error
+libze_plugin_systemdboot_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_data) {
+    libze_error  ret = LIBZE_ERROR_SUCCESS;
+
+    char mountpoint_buf[LIBZE_MAX_PATH_LEN] = "";
+
+    if (snap_data->is_root) {
+        (void) strlcat(mountpoint_buf, "/", LIBZE_MAX_PATH_LEN);
+    } else {
+        /* Get temporary mountpoint and place in mountpoint_buf */
+        ret = libze_mount(lzeh, snap_data->be_name, NULL, mountpoint_buf);
+        if (ret != LIBZE_ERROR_SUCCESS) {
+            return ret;
+        }
+    }
+
+    /* Copy the following for that environment to $kernelsnapshotdirectory.
+     *  $esp/env/org.zectl-$be -> $kernelsnapshotdirectory/env/boot
+     *  $esp/loader/entries/org.zectl-$be.conf -> $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf
+     */
+
+    if (!snap_data->is_root) {
+        ret = libze_unmount(lzeh, snap_data->be_name);
+        if (ret != LIBZE_ERROR_SUCCESS) {
+            return ret;
+        }
+    }
+
+    return ret;
+}

--- a/lib/libze_plugin/libze_plugin_systemdboot.c
+++ b/lib/libze_plugin/libze_plugin_systemdboot.c
@@ -1353,6 +1353,20 @@ libze_plugin_systemdboot_post_rename(libze_handle *lzeh, char const be_name_old[
     return ret;
 }
 
+/**
+ * @brief Pre snapshot hook
+ *        Mounts the dataset being snapshotted (if it is not the currently mounted dataset).
+ *        Copies the following for that environment to $kernelsnapshotdirectory.
+ *           $esp/env/org.zectl-$be -> $kernelsnapshotdirectory/env/boot
+ *           $esp/loader/entries/org.zectl-$be.conf -> $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf
+ *        Unmounts the dataset
+ *
+ * @param[in,out] lzeh   libze handle
+ * @param[in] snap_data  Snapshot related data
+ * @return @p LIBZE_ERROR_SUCCESS on success,
+ *         @p LIBZE_ERROR_MAXPATHLEN on path exceeded,
+ *         @p LIBZE_ERROR_UNKNOWN otherwise
+ */
 libze_error
 libze_plugin_systemdboot_pre_snapshot(libze_handle *lzeh, libze_snap_data *snap_data) {
     libze_error ret = LIBZE_ERROR_SUCCESS;

--- a/lib/libze_plugin/libze_plugin_systemdboot.c
+++ b/lib/libze_plugin/libze_plugin_systemdboot.c
@@ -12,13 +12,13 @@
 #define SYSTEMDBOOT_ENTRY_PREFIX "org.zectl"
 
 #define NUM_SYSTEMDBOOT_PROPERTY_VALUES 2
-#define NUM_SYSTEMDBOOT_PROPERTIES 2
+#define NUM_SYSTEMDBOOT_PROPERTIES 3
 
 /**
  * @brief list of systemdboot plugin properties
  */
 char const *systemdboot_properties[NUM_SYSTEMDBOOT_PROPERTIES][NUM_SYSTEMDBOOT_PROPERTY_VALUES] = {
-    {"efi", "/efi"}, {"boot", "/boot"}};
+    {"efi", "/efi"}, {"boot", "/boot"}, {"kernelsnapshotdirectory", "/zectl/systemdboot"}};
 
 /**
  * @struct replace_matched_data


### PR DESCRIPTION
# Description

With systemd-boot there is no snapshot of the kernel, there is only the directory hierarchy of kernels which is named in a similar way to the boot environment which is how we relate them. Currently when you restore from an existing snapshot, the active kernel is used. Using the active kernel can be a problem, kernel modules can get out of sync.

Presently there is no way to get the kernel because a snapshot doesn't have a kernel associated with it.

The proposed solution brought up by @GregoryLand https://github.com/johnramsden/zectl/issues/15#issuecomment-626076852 is to create a 'snapshot' of the kernel in use by the environment and save it on the actual dataset snapshot.

# Implementation

The implementation plan is to add a property `kernelsnapshotdirectory` that specifies the location of this 'snapshot' under the `org.zectl.systemdboot` namespace with the default set to `/zectl/systemdboot`.

When a snapshot is taken, a `systemdboot` pre-hook will:

1. Mount the dataset being snapshotted (if it is not the currently mounted dataset).
2. Copy the following for that environment to `$kernelsnapshotdirectory`.
    1. `$esp/env/org.zectl-$be -> $kernelsnapshotdirectory/env/boot`
    1. `$esp/loader/entries/org.zectl-$be.conf -> $kernelsnapshotdirectory/loader/entries/org.zectl-%ZECTLBE%.conf`
3. Unmount the dataset, and complete taking the snapshot

When create is done, the existing `systemdboot` post-hook will:

1. Pass in a new boolean `from_existing`.
2. If `from_existing` is true, we look for `$kernelsnapshotdirectory`, if it exists we use the kernel contained and possibly the configuration instead of using the active configuration and kernel. If the directory does not exist we leave the kernel empty, and emit an error message.
3. `/zectl/systemdboot` is deleted.