### PR TITLE
Make sure we are able to use zectl without any boot loader plugin

### DIFF
--- a/lib/libze/libze_bootloader.c
+++ b/lib/libze/libze_bootloader.c
@@ -25,7 +25,7 @@ libze_bootloader_init(libze_handle *lzeh, libze_bootloader *bootloader,
         return LIBZE_ERROR_UNKNOWN;
     }
 
-    if (nvlist_lookup_nvlist(out_props, prop, &bootloader->prop) != 0) {
+    if (nvlist_lookup_nvlist(out_props, prop, &bootloader->prop) == 0) {
         bootloader->set = B_TRUE;
     }
 

--- a/src/zectl_create.c
+++ b/src/zectl_create.c
@@ -14,12 +14,9 @@
 libze_error
 ze_create(libze_handle *lzeh, int argc, char **argv) {
 
-    libze_bootloader bootloader = { 0 };
-
     libze_create_options be_clone = {.existing = B_FALSE, .recursive = B_FALSE};
 
     libze_error ret = LIBZE_ERROR_SUCCESS;
-    bootloader.set = B_FALSE;
 
     char *be_existing = NULL;
 
@@ -55,11 +52,6 @@ ze_create(libze_handle *lzeh, int argc, char **argv) {
         return LIBZE_ERROR_MAXPATHLEN;
     }
 
-    if ((ret = libze_bootloader_init(lzeh, &bootloader, ZE_PROP_NAMESPACE)) !=
-        LIBZE_ERROR_SUCCESS) {
-        goto err;
-    }
-
     if (be_clone.existing) {
         if (strlcpy(be_clone.be_source, be_existing, ZFS_MAX_DATASET_NAME_LEN) >=
             ZFS_MAX_DATASET_NAME_LEN) {
@@ -71,6 +63,5 @@ ze_create(libze_handle *lzeh, int argc, char **argv) {
     ret = libze_create(lzeh, &be_clone);
 
 err:
-    libze_bootloader_fini(&bootloader);
     return ret;
 }

--- a/src/zectl_create.c
+++ b/src/zectl_create.c
@@ -14,7 +14,7 @@
 libze_error
 ze_create(libze_handle *lzeh, int argc, char **argv) {
 
-    libze_bootloader bootloader;
+    libze_bootloader bootloader = { 0 };
 
     libze_create_options be_clone = {.existing = B_FALSE, .recursive = B_FALSE};
 


### PR DESCRIPTION
This PR fixes 2 issues:
1) We were not initialising `bootloader` and using it expecting that it was initialised. This results in behaviour where if no prop has been set for the bootloader, `bootloader.prop` is not `NULL` as it gets the value which was on the stack when it was declared and then we error out at `libze_bootloader_fini` in this scenario.
2) `nvlist_lookup_nvlist` returns 0 on success and otherwise it's an error. So we should only have `B_TRUE` set if we were able to find the bootloader prop set. 