### PR TITLE
Use current running env path to determine active BE

### DIFF
--- a/lib/libze/libze.c
+++ b/lib/libze/libze.c
@@ -2271,7 +2271,7 @@ libze_list_cb(zfs_handle_t *zhdl, void *data) {
     fnvlist_add_boolean_value(props, "nextboot", is_nextboot);
 
     // Active
-    boolean_t is_active = (is_mounted == 0) && (strcmp(mountpoint, "/") == 0);
+    boolean_t is_active = (is_mounted == 0) && (strcmp(cbd->lzeh->env_running_path, dataset) == 0);
     fnvlist_add_boolean_value(props, "active", is_active);
 
     fnvlist_add_nvlist(*cbd->outnvl, prop_buffer, props);


### PR DESCRIPTION
In my use case, I have BE's with legacy mountpoints set. GRUB decides which BE to boot, I understand that GRUB support is a WIP in zectl, however I noticed that zectl does not show the correct active BE which on looking closer I found was because it tried to confirm the value of the mountpoint. That in my opinion is a good check but isn't it better to trust lzeh.env_running_path path ? I am not certain how zectl intends to handle this case with GRUB ( mountpoints of active BE's ) but to have legacy mountpoint set and have GRUB booting from it, I don't see any issue in trusting lzeh.env_running_path instead as that should always get us the active BE's dataset name.
