### PR TITLE
Remove zfs_iter_filesystems from libze_activate and libze_clone

### DIFF
--- a/lib/libze/libze.c
+++ b/lib/libze/libze.c
@@ -1412,12 +1412,6 @@ libze_activate(libze_handle *lzeh, libze_activate_options *options) {
         goto err;
     }
 
-    // Set for all child datasets and promote
-    if (zfs_iter_filesystems(be_zh, libze_clone_cb, &cbd) != 0) {
-        ret = LIBZE_ERROR_UNKNOWN;
-        goto err;
-    }
-
     if (be_bpool_zh != NULL) {
         if (libze_activate_cb(be_bpool_zh, &cbd) != 0) {
             ret = libze_error_set(
@@ -1578,14 +1572,6 @@ libze_clone(libze_handle *lzeh, char source_root[static 1], char source_snap_suf
         // libze_clone_cb sets error message.
         ret = LIBZE_ERROR_UNKNOWN;
         goto err;
-    }
-
-    if (recursive) {
-        if (zfs_iter_filesystems(zroot_hdl, libze_clone_cb, &cbd) != 0) {
-            // libze_clone_cb sets error message.
-            ret = LIBZE_ERROR_UNKNOWN;
-            goto err;
-        }
     }
 
     nvpair_t *pair = NULL;


### PR DESCRIPTION
In libze_activate(), libze_activate_cbdata is passed as cbd to zfs_iter_filesystems() with callback function libze_clone_cb(), which interprets it as libze_clone_cbdata. Both libze_activate_cbdata and libze_activate_cbdata have different members. When libze_clone_cb() is invoked during activate and there are any child datasets in BE, segmentation fault is generated because of using incorrect addresses formed when libze_activate_cbdata is interpretted as libze_clone_cbdata. Moreover, properties of child datasets should not be cloned during activate operation, as they are already cloned during create operation.

In libze_clone(), libze_clone_cb() is called, which already performs zfs_iter_filesystems() if recursive flag is set. Calling zfs_iter_filesystems() again from libze_clone() after calling libze_clone_cb() should not be needed.