### PR TITLE
Proposed solution to make CMakefiles to use option() for BUILD_TESTING

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,17 +12,12 @@ include(FindZFS)
 
 if (CMAKE_VERSION VERSION_LESS 3.12)
     add_definitions(-DDEBUG=0)
-    add_definitions(-DBUILD_TESTING=0)
 else()
     add_compile_definitions(DEBUG=0)
-    add_compile_definitions(BUILD_TESTING=0)
 endif()
 
 add_subdirectory(lib)
 add_subdirectory(src)
-
-if (BUILD_TESTING)
-    add_subdirectory(tests)
-endif()
+add_subdirectory(tests)
 
 unset(PLUGINS_DIRECTORY CACHE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,18 +1,22 @@
-enable_testing()
-find_package(Check REQUIRED)
+option(BUILD_TESTING "Create all tests" NO)
 
-# Needed for ubuntu - see https://github.com/libcheck/check/issues/48
-find_package(Threads REQUIRED)
+if (BUILD_TESTING)
+    enable_testing()
+    find_package(Check REQUIRED)
 
-include_directories(${CHECK_INCLUDE_DIRS})
+    # Needed for ubuntu - see https://github.com/libcheck/check/issues/48
+    find_package(Threads REQUIRED)
 
-set(LIBS ${LIBS} ${CHECK_LIBRARIES}
-        ${ZE_LINK_LIBRARIES}
-        ${CMAKE_THREAD_LIBS_INIT}
-        libze util)
+    include_directories(${CHECK_INCLUDE_DIRS})
 
-include_directories(. ../include)
+    set(LIBS ${LIBS} ${CHECK_LIBRARIES}
+         ${ZE_LINK_LIBRARIES}
+         ${CMAKE_THREAD_LIBS_INIT}
+         libze util)
 
-add_executable(zectl_tests zectl_tests.c zectl_tests.h)
-target_link_libraries(zectl_tests ${LIBS})
-add_test(zectl_tests ${CMAKE_CURRENT_BINARY_DIR}/zectl_tests)
+    include_directories(. ../include)
+
+    add_executable(zectl_tests zectl_tests.c zectl_tests.h)
+    target_link_libraries(zectl_tests ${LIBS})
+    add_test(zectl_tests ${CMAKE_CURRENT_BINARY_DIR}/zectl_tests)
+endif()


### PR DESCRIPTION
This should let the CMake ecosystem see the BUILD_TESTING flag correctly. This will resolve #51 